### PR TITLE
Make Vault and Consul base paths configurable

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"errors"
+	"os"
 	"reflect"
 	"strings"
 )
@@ -253,4 +254,12 @@ func GetReflectElem(val interface{}) (reflect.Value, error) {
 	}
 
 	return refVal.Elem(), nil
+}
+
+func GetEnvWithFallback(name string, fallback string) string {
+	if val := os.Getenv(name); val != "" {
+		return val
+	}
+
+	return fallback
 }

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -256,6 +256,8 @@ func GetReflectElem(val interface{}) (reflect.Value, error) {
 	return refVal.Elem(), nil
 }
 
+// GetEnvWithFallback tries to load a value from an env variable by its name and gives back a given fallback value in
+// case the requested variable is empty.
 func GetEnvWithFallback(name string, fallback string) string {
 	if val := os.Getenv(name); val != "" {
 		return val

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -205,5 +206,35 @@ func mapIterator(fieldMap map[string]string) IteratorFunc {
 		}
 
 		return SetReflectValueString(fieldName, val, field)
+	}
+}
+
+func TestGetEnvWithFallback(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		fallback string
+		expected string
+	}{
+		{
+			name:     "get_value_from_environment",
+			value:    "environment-variable-value",
+			fallback: "fallback-value",
+			expected: "environment-variable-value",
+		},
+		{
+			name:     "get_value_from_fallback",
+			value:    "",
+			fallback: "fallback-value",
+			expected: "fallback-value",
+		},
+	}
+	for _, scenario := range tests {
+		t.Run(scenario.name, func(t *testing.T) {
+			err := os.Setenv("TEST_ENVIRONMENT_VAR", scenario.value)
+			assert.NoError(t, err)
+
+			assert.Equal(t, scenario.expected, GetEnvWithFallback("TEST_ENVIRONMENT_VAR", scenario.fallback))
+		})
 	}
 }

--- a/loader/consul.go
+++ b/loader/consul.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/worldline-go/igconfig/internal"
 	"os"
 	"path"
 
@@ -12,11 +13,14 @@ import (
 	"github.com/hashicorp/consul/api"
 )
 
-// ConsulTag is a tag used to identify field name.
-var ConsulTag = "cfg"
+// ConsulConfigDefaultPathPrefix stores the default base path for secrets.
+const ConsulConfigDefaultPathPrefix = "finops"
 
-// ConsulConfigPathPrefix specifies prefix for key search.
-var ConsulConfigPathPrefix = "finops"
+// ConsulConfigPathPrefixEnv holds the name of the env variable that is used to set custom path prefix.
+const ConsulConfigPathPrefixEnv = "CONSUL_CONFIG_PATH_PREFIX"
+
+// ConsulTag is a tag used to identify field name.
+const ConsulTag = "cfg"
 
 var _ Loader = Consul{}
 
@@ -62,7 +66,7 @@ func (l Consul) LoadWithContext(ctx context.Context, appName string, to interfac
 
 	queryOptions := api.QueryOptions{}
 	data, _, err := l.Client.KV().Get(
-		path.Join(ConsulConfigPathPrefix, appName),
+		path.Join(internal.GetEnvWithFallback(ConsulConfigPathPrefixEnv, ConsulConfigDefaultPathPrefix), appName),
 		queryOptions.WithContext(ctx),
 	)
 	// If no data or err is returned - return early.

--- a/loader/consul.go
+++ b/loader/consul.go
@@ -4,13 +4,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/worldline-go/igconfig/internal"
 	"os"
 	"path"
 
-	"github.com/worldline-go/igconfig/codec"
-
 	"github.com/hashicorp/consul/api"
+	"github.com/worldline-go/igconfig/codec"
+	"github.com/worldline-go/igconfig/internal"
 )
 
 // ConsulConfigDefaultPathPrefix stores the default base path for secrets.

--- a/loader/consulDynamic.go
+++ b/loader/consulDynamic.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/consul/api/watch"
 	"github.com/hashicorp/go-hclog"
 	"github.com/rs/zerolog/log"
+	"github.com/worldline-go/igconfig/internal"
 )
 
 // DynamicValue allows to get dynamically updated values at a runtime.
@@ -44,7 +45,7 @@ func (l Consul) DynamicValue(ctx context.Context, key string) (<-chan []byte, er
 	if l.Plan == nil {
 		plan, err := watch.Parse(map[string]interface{}{
 			"type": "key",
-			"key":  path.Join(ConsulConfigPathPrefix, key),
+			"key":  path.Join(internal.GetEnvWithFallback(ConsulConfigPathPrefixEnv, ConsulConfigDefaultPathPrefix), key),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("wath.Parse %w", err)

--- a/loader/consul_test.go
+++ b/loader/consul_test.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/worldline-go/igconfig/codec"
-	"github.com/worldline-go/igconfig/internal"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -19,6 +17,8 @@ import (
 
 	"github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/assert"
+	"github.com/worldline-go/igconfig/codec"
+	"github.com/worldline-go/igconfig/internal"
 )
 
 func TestLoadFromConsul(t *testing.T) {

--- a/loader/vault.go
+++ b/loader/vault.go
@@ -36,7 +36,7 @@ const VaultRoleIDEnv = "VAULT_ROLE_ID"
 const VaultRoleSecretEnv = "VAULT_ROLE_SECRET" // nolint:gosec // false-positive
 
 // VaultAppRoleBasePathEnv specifies the name of the environment variable that holds the path to login.
-const VaultAppRoleBasePathEnv = "VAULT_APP_ROLE_BASE_PATH"
+const VaultAppRoleBasePathEnv = "VAULT_APPROLE_BASE_PATH"
 
 // VaultSecretBasePathEnv specifies the name of the environment variable that holds the base path to secrets.
 const VaultSecretBasePathEnv = "VAULT_SECRET_BASE_PATH"

--- a/loader/vault_test.go
+++ b/loader/vault_test.go
@@ -464,8 +464,11 @@ func TestVault_LoginPath(t *testing.T) {
 			}))
 			defer server.Close()
 
-			os.Setenv("VAULT_ADDR", server.URL)
-			os.Setenv(VaultAppRoleBasePathEnv, scenario.env)
+			err := os.Setenv("VAULT_ADDR", server.URL)
+			assert.NoError(t, err)
+
+			err = os.Setenv(VaultAppRoleBasePathEnv, scenario.env)
+			assert.NoError(t, err)
 
 			SetAppRole("dummy-role-id", "dummy-secret-id")
 		}()
@@ -516,7 +519,8 @@ func TestVault_SecretPath(t *testing.T) {
 			assert.NoError(t, err)
 
 			if scenario.basePath != "" {
-				os.Setenv(VaultSecretBasePathEnv, scenario.basePath)
+				err = os.Setenv(VaultSecretBasePathEnv, scenario.basePath)
+				assert.NoError(t, err)
 			}
 
 			resp := map[string]interface{}{}

--- a/loader/vault_test.go
+++ b/loader/vault_test.go
@@ -2,6 +2,9 @@ package loader
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
@@ -384,7 +387,7 @@ func (v VaultMock) Read(path string) (*api.Secret, error) {
 		return nil, v.err
 	}
 
-	path = strings.TrimPrefix(strings.TrimPrefix(path, VaultSecretBasePath), "/")
+	path = strings.TrimPrefix(strings.TrimPrefix(path, VaultSecretDefaultBasePath), "/")
 
 	data, ok := v.data[path]
 	if !ok {
@@ -401,7 +404,7 @@ func (v VaultMock) Read(path string) (*api.Secret, error) {
 }
 
 func (v VaultMock) List(path string) (*api.Secret, error) {
-	path = strings.TrimPrefix(strings.TrimPrefix(path, VaultSecretBasePath), "/")
+	path = strings.TrimPrefix(strings.TrimPrefix(path, VaultSecretDefaultBasePath), "/")
 
 	if keys, ok := v.list[path]; ok {
 		return &api.Secret{
@@ -436,24 +439,88 @@ func TestNewVaulterer_RoleID(t *testing.T) {
 	}, s)
 }
 
-func TestNewVaulterer_Token(t *testing.T) {
-	// This test requires for Vault to be running and token to be known
-	addr, token := os.Getenv("VAULT_HOST"), os.Getenv("VAULT_TOKEN")
-
-	if addr == "" || token == "" {
-		t.Skip("vault address and token must be provided")
-	}
-
-	v, err := NewVaulterer(addr, SetToken(token))
-	assert.NoError(t, err)
-
-	var s testStruct
-
-	require.NoError(t, v.Load("test", &s))
-	assert.Equal(t, testStruct{
-		Field1: "one",
-		Inner: inner{
-			Field2: "other",
+func TestVault_LoginPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		env      string
+		expected string
+	}{
+		{
+			name:     "login_on_default_path",
+			env:      "",
+			expected: VaultAppRoleDefaultBasePath,
 		},
-	}, s)
+		{
+			name:     "login_on_custom_path",
+			env:      "auth/finops/approle/login",
+			expected: "auth/finops/approle/login",
+		},
+	}
+	for _, scenario := range tests {
+		func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, scenario.expected, r.URL.Path)
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			os.Setenv("VAULT_ADDR", server.URL)
+			os.Setenv(VaultAppRoleBasePathEnv, scenario.env)
+
+			SetAppRole("dummy-role-id", "dummy-secret-id")
+		}()
+	}
+}
+
+func TestVault_SecretPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		basePath string
+	}{
+		{
+			name: "get_secrets_on_default_path",
+		},
+		{
+			name:     "get_secrets_on_custom_path",
+			basePath: "finops/kv2",
+		},
+	}
+	for _, scenario := range tests {
+		func() {
+			expectedBasePath := VaultSecretDefaultBasePath
+			if scenario.basePath != "" {
+				expectedBasePath = scenario.basePath
+			}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case fmt.Sprintf("/v1/%s/metadata/generic", expectedBasePath):
+					fallthrough
+				case fmt.Sprintf("/v1/%s/data/generic", expectedBasePath):
+					fallthrough
+				case fmt.Sprintf("/v1/%s/metadata/hello-finops", expectedBasePath):
+					fallthrough
+				case fmt.Sprintf("/v1/%s/data/hello-finops", expectedBasePath):
+					w.WriteHeader(http.StatusOK)
+				default:
+					t.Errorf("Invalid request path: %s", r.URL.Path)
+					t.Fail()
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+
+			v, err := NewVaulterer(server.URL, func(*api.Client) error {
+				return nil
+			})
+			assert.NoError(t, err)
+
+			if scenario.basePath != "" {
+				os.Setenv(VaultSecretBasePathEnv, scenario.basePath)
+			}
+
+			resp := map[string]interface{}{}
+			assert.NoError(t, v.Load("hello-finops", &resp))
+		}()
+	}
 }


### PR DESCRIPTION
Add 3 environment variables (VAULT_APPROLE_BASE_PATH, VAULT_SECRET_BASE_PATH and CONSUL_CONFIG_PATH_PREFIX) to be able to set custom base paths for Vault and Consul.